### PR TITLE
JSONP compatibility and new request content option

### DIFF
--- a/Source/options.html
+++ b/Source/options.html
@@ -55,6 +55,15 @@
 			<label>ms</label>
 		</div>
 
+		<div id="moduleShowResponseObjectStandalone">
+			<h2>Include Request Content Standalone</h2>
+			<div class="notice">This combines GET and POST data and logs outside [Object]</div>
+
+			<select id="prefRequestContentStandalone">
+				<option value="true">Yes</option>
+				<option value="false">No</option>
+			</select>
+		</div>
 
 		<div id="moduleShowResponseObject">
 			<h2>Show Response [Object]</h2>

--- a/Source/scripts/background.js
+++ b/Source/scripts/background.js
@@ -4,8 +4,9 @@
 
 
 const tab_log = function(json_args) {
-	var args = JSON.parse(unescape(json_args));
-	console[args[0]].apply(console, Array.prototype.slice.call(args, 1));
+	var argslist = JSON.parse(unescape(json_args));
+	for (var i=0; i<argslist.length; i++)
+		console[argslist[i][0]].apply(console, argslist[i].slice(1)); //Array.prototype.slice not needed, as JSON.parse returns proper arrays
 }
 
 chrome.extension.onRequest.addListener(function(request) {

--- a/Source/scripts/debugger.js
+++ b/Source/scripts/debugger.js
@@ -154,6 +154,7 @@ AJAXDebugger.load = function(request) {
 	if (prefTimerEnabled == "true" && responseTime >= prefTimerTimeout) { prefGroupExpanded = "true"; }
 
 	var render = function(content) {
+		Console.buffer();
 		if (prefGroupExpanded == "true") { Console.group(header); }
 		else { Console.groupCollapsed(header); }
 
@@ -232,6 +233,7 @@ AJAXDebugger.load = function(request) {
 		// AJAXDebugger.pager();
 
 		Console.groupEnd();
+		Console.flush();
 	}
 
 	if (prefShowResponseObject == "true" && prefResponseContent == "true") {

--- a/Source/scripts/debugger.js
+++ b/Source/scripts/debugger.js
@@ -200,6 +200,7 @@ AJAXDebugger.load = function(request) {
 		if(prefRequestContentStandalone == "true") {
 			/* Compile the request parameters into an object */
 			var requestObject={};
+			function decodeVal(s) { return decodeURIComponent(s.replace(/\+/g, ' ')); }
 			function addToRequestObject(memberLookupArray) { /* memberLookupArray=[object, MEMBERNAME, MEMBERNAME, ...] */
 				/* Get the member if it exists, or exit otherwise */
 				var lookupObj=memberLookupArray[0];
@@ -209,7 +210,7 @@ AJAXDebugger.load = function(request) {
 
 				/* Get the items from the parameter array */
 				for(var i=0;i<lookupObj.length;i++)
-					requestObject[lookupObj[i].name]=lookupObj[i].value;
+					requestObject[decodeVal(lookupObj[i].name)]=decodeVal(lookupObj[i].value);
 
 			}
 			//addToRequestObject([request, 'request', 'cookies']); /* Add cookies to request object */

--- a/Source/scripts/debugger.js
+++ b/Source/scripts/debugger.js
@@ -142,14 +142,14 @@ AJAXDebugger.load = function(request) {
 	responseTimePrint = AJAXDebugger.formatTime(responseTime);
 	responseSize = AJAXDebugger.formatSize(responseSize);
 
-	var header = 
-		"XHR Loaded (" + 
+	var header =
+		"XHR Loaded (" +
 		requestLocation + textSeperator +
 		responseStatus + textSeperator +
 		responseTimePrint + textSeperator +
 		responseSize +
 		")";
-	
+
 	/* If long response, expand */
 	if (prefTimerEnabled == "true" && responseTime >= prefTimerTimeout) { prefGroupExpanded = "true"; }
 
@@ -164,7 +164,7 @@ AJAXDebugger.load = function(request) {
 		if (prefTimerEnabled == "true" && responseTime >= prefTimerTimeout) {
 			Console.warn("Time over " + prefTimerTimeout + "ms");
 		}
-		
+
 		/* Response body */
 		var contentParsed = null;
 		if (content) {

--- a/Source/scripts/debugger.js
+++ b/Source/scripts/debugger.js
@@ -165,7 +165,13 @@ AJAXDebugger.load = function(request) {
 		var contentParsed = null;
 		if (content) {
 			try {
-				contentParsed = JSON.parse(content);
+				/* Handle JSONP */
+				var contentToParse=content;
+				var checkForJSONP=content.match(/^[ \t]*[\w-]+[ \t*]*\(([\s\S]+)\)[ \t*]*;?\s*$/);
+				if(checkForJSONP!==null)
+					contentToParse=checkForJSONP[1];
+
+				contentParsed = JSON.parse(contentToParse);
 				request.responseContent = contentParsed;
 			}
 			catch (e) {

--- a/Source/scripts/debugger.js
+++ b/Source/scripts/debugger.js
@@ -197,7 +197,7 @@ AJAXDebugger.load = function(request) {
 		}
 
 		/* Request content, outside of object */
-		if(prefRequestContentStandalone == "true") {
+		function GetReqestData() {
 			/* Compile the request parameters into an object */
 			var requestObject={};
 			function decodeVal(s) { return decodeURIComponent(s.replace(/\+/g, ' ')); }
@@ -217,7 +217,10 @@ AJAXDebugger.load = function(request) {
 			addToRequestObject([request, 'request', 'queryString']); /* Add get to request object */
 			addToRequestObject([request, 'request', 'postData', 'params']); /* Add post to request object */
 
-			Console.log("Request", requestObject);
+			return requestObject;
+		}
+		if(prefRequestContentStandalone == "true") {
+			Console.log("Request", GetReqestData());
 		}
 
 		/* Response content, outside of object */

--- a/Source/scripts/debugger.js
+++ b/Source/scripts/debugger.js
@@ -20,6 +20,9 @@ if (!localStorage["prefResponseContent"]) {
 if (!localStorage["prefResponseContentStandalone"]) {
 	localStorage["prefResponseContentStandalone"] = "false";
 }
+if (!localStorage["prefRequestContentStandalone"]) {
+	localStorage["prefRequestContentStandalone"] = "false";
+}
 
 
 chrome.devtools.network.onRequestFinished.addListener(function(request) {
@@ -110,6 +113,7 @@ AJAXDebugger.load = function(request) {
 		prefTimerTimeout = localStorage["prefTimerTime"],
 		prefResponseContent = localStorage["prefResponseContent"];
 		prefResponseContentStandalone = localStorage["prefResponseContentStandalone"];
+		prefRequestContentStandalone = localStorage["prefRequestContentStandalone"];
 		prefShowResponseObject = localStorage["prefShowResponseObject"];
 
 	for (var i=0, len=params.length; i<len; i++) {
@@ -190,6 +194,29 @@ AJAXDebugger.load = function(request) {
 			} else {
 				Console.log("XHR Data", request);
 			}
+		}
+
+		/* Request content, outside of object */
+		if(prefRequestContentStandalone == "true") {
+			/* Compile the request parameters into an object */
+			var requestObject={};
+			function addToRequestObject(memberLookupArray) { /* memberLookupArray=[object, MEMBERNAME, MEMBERNAME, ...] */
+				/* Get the member if it exists, or exit otherwise */
+				var lookupObj=memberLookupArray[0];
+				for(var i=1;i<memberLookupArray.length;i++)
+					if(!(lookupObj=lookupObj[memberLookupArray[i]]))
+						return;
+
+				/* Get the items from the parameter array */
+				for(var i=0;i<lookupObj.length;i++)
+					requestObject[lookupObj[i].name]=lookupObj[i].value;
+
+			}
+			//addToRequestObject([request, 'request', 'cookies']); /* Add cookies to request object */
+			addToRequestObject([request, 'request', 'queryString']); /* Add get to request object */
+			addToRequestObject([request, 'request', 'postData', 'params']); /* Add post to request object */
+
+			Console.log("Request", requestObject);
 		}
 
 		/* Response content, outside of object */

--- a/Source/scripts/options.js
+++ b/Source/scripts/options.js
@@ -8,6 +8,7 @@ var defGroupExpanded = "false",
 	defShowResponseObject = "true";
 	defResponseContent = "false",
 	defResponseContentStandalone = "false";
+	defRequestContentStandalone = "false";
 
 loadOptions();
 bindEvents();
@@ -28,6 +29,7 @@ function bindEvents() {
 		localStorage["prefTimerTime"] = parseInt(getSelectValue("prefTimerTime"));
 		localStorage["prefResponseContent"] = getSelectValue("prefResponseContent");
 		localStorage["prefResponseContentStandalone"] = getSelectValue("prefResponseContentStandalone");
+		localStorage["prefRequestContentStandalone"] = getSelectValue("prefRequestContentStandalone");
 		localStorage["prefShowResponseObject"] = getSelectValue("prefShowResponseObject");
 
 		renderNoticePref("Preferences Saved");
@@ -42,6 +44,7 @@ function bindEvents() {
 			localStorage["prefTimerTime"] = defTimerTime;
 			localStorage["prefResponseContent"] = defResponseContent;
 			localStorage["prefResponseContentStandalone"] = defResponseContentStandalone;
+			localStorage["prefRequestContentStandalone"] = defRequestContentStandalone;
 			localStorage["prefShowResponseObject"] = defShowResponseObject;
 			renderNoticePref("Default preferences loaded");
 
@@ -67,6 +70,7 @@ function loadOptions() {
 		timerTime = localStorage["prefTimerTime"] || defTimerTime;
 		responseContent = localStorage["prefResponseContent"] || defResponseContent;
 		responseObjectStandalone = localStorage["prefResponseContentStandalone"] || defResponseContentStandalone;
+		requestObjectStandalone = localStorage["prefRequestContentStandalone"] || defRequestContentStandalone;
 		responseObject = localStorage["prefShowResponseObject"] || defShowResponseObject;
 
 	setSelectValue("prefGroupExpanded", groupExpanded);
@@ -74,6 +78,7 @@ function loadOptions() {
 	document.getElementById("prefTimerTime").value = timerTime;
 	setSelectValue("prefResponseContent", responseContent);
 	setSelectValue("prefResponseContentStandalone", responseObjectStandalone);
+	setSelectValue("prefRequestContentStandalone", requestObjectStandalone);
 	setSelectValue("prefShowResponseObject", responseObject);
 
 	displayLoadResponseContent($("#prefShowResponseObject"));  //Show #moduleLoadResponseContent


### PR DESCRIPTION
Response content now accounts for JSONP's wrapper function
Added "Include Request Content Standalone" option
Grouped console commands are now run atomically so they cannot be output out of order
